### PR TITLE
Remove BatteryService

### DIFF
--- a/src/SupportedDevices.ts
+++ b/src/SupportedDevices.ts
@@ -14,7 +14,6 @@ export function listKnownServices(api: API, parent: SupportedServices): WithUUID
     api.hap.Service.AccessoryInformation,
     api.hap.Service.Switch,
     api.hap.Service.MotionSensor,
-    api.hap.Service.BatteryService,
     api.hap.Service.Battery,
     api.hap.Service.Lightbulb,
     api.hap.Service.Outlet,


### PR DESCRIPTION
Removing this as it is a depreciated Service which has now been removed in HAP-NodeJS v1.0.0